### PR TITLE
[Cycode] Fix for vulnerable manifest file dependency - gitpython updated to version 3.1.30

### DIFF
--- a/gitea/Pipfile
+++ b/gitea/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 requests = "*"
 click = "*"
 pyyaml = "*"
-gitpython = "*"
+gitpython = "==3.1.30"
 
 [dev-packages]
 


### PR DESCRIPTION
# Cycode Vulnerable Dependencies Update 
This pull request updates the following manifest file:

| File Path | Number of packages to update |
|---|---|
| `gitea/Pipfile` | 1 |

<details>
<summary><h3>:open_file_folder: gitea/Pipfile</h3></summary>

1 package will be updated to resolve vulnerabilities:

| Package Name | Current Version | Updated Version | 
|---|---|---|
| `gitpython` | 3.1.27 | 3.1.30 |
</details>

> [!WARNING]
> Lock file generation failed for one or more manifest files in this pull request. Please regenerate the lock file manually before merging.
